### PR TITLE
Fix: Update workflow to trigger on master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The repository's default branch is master, but the workflow was only configured to run on main. This caused the deployment to fail when the PR was merged to master.

Now the workflow triggers on both master and main branches.