### PR TITLE
Add dates and AI transparency disclaimers to musings articles

### DIFF
--- a/public/content/musings/ai-code-review-workflow.md
+++ b/public/content/musings/ai-code-review-workflow.md
@@ -1,5 +1,7 @@
 # Integrating AI into Code Review Workflows
 
+*November 9, 2025*
+
 Code review is where we catch bugs, share knowledge, and maintain standards. AI assistants are increasingly being integrated into this critical process - but how do we do it without losing the human insight that makes reviews valuable?
 
 ## The Promise and the Pitfall
@@ -266,3 +268,7 @@ The best code review process leverages AI's speed and consistency while preservi
 ---
 
 **How does your team handle code review?** Are you using AI tools? What's working and what isn't? Share your experiences—the community learns from real-world implementations.
+
+---
+
+*This article was created with AI assistance using Claude Sonnet 4.5 (claude-sonnet-4-5-20250929).*

--- a/public/content/musings/ai-pair-programming-best-practices.md
+++ b/public/content/musings/ai-pair-programming-best-practices.md
@@ -1,5 +1,7 @@
 # AI Pair Programming: Best Practices
 
+*November 9, 2025*
+
 AI coding assistants have transformed how we write software, but like any tool, their effectiveness depends on how we use them. After working extensively with AI pair programming tools, I've identified key practices that maximize value while maintaining code quality and learning.
 
 ## Understanding the Partnership
@@ -94,3 +96,7 @@ As these tools evolve, the developers who thrive will be those who master the ar
 ---
 
 **What's your experience with AI pair programming?** I'd love to hear what patterns you've discovered and pitfalls you've avoided. The field is evolving rapidly, and we all benefit from shared learnings.
+
+---
+
+*This article was created with AI assistance using Claude Sonnet 4.5 (claude-sonnet-4-5-20250929).*

--- a/public/content/musings/prompt-engineering-for-developers.md
+++ b/public/content/musings/prompt-engineering-for-developers.md
@@ -1,5 +1,7 @@
 # Prompt Engineering for Software Engineers
 
+*November 9, 2025*
+
 As developers increasingly work alongside AI assistants, prompt engineering has become an essential skill. But unlike traditional APIs with defined interfaces, AI models respond to natural language - making the quality of your questions as important as your code.
 
 ## The Developer's Advantage
@@ -219,3 +221,7 @@ As AI tools become central to development workflows, this skill will differentia
 ---
 
 **What prompt patterns work best for you?** Share your discoveries—we're all learning together.
+
+---
+
+*This article was created with AI assistance using Claude Sonnet 4.5 (claude-sonnet-4-5-20250929).*


### PR DESCRIPTION
Changes:
- Add publication date (November 9, 2025) based on PR #5 creation date
- Add AI transparency disclaimer at bottom of each article
- Disclose use of Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)

Updated articles:
- ai-code-review-workflow.md
- ai-pair-programming-best-practices.md
- prompt-engineering-for-developers.md