### PR TITLE
Update article date to December 10, 2025

### DIFF
--- a/public/content/musings-manifest.json
+++ b/public/content/musings-manifest.json
@@ -6,7 +6,7 @@
       "slug": "the-uneven-revolution",
       "category": "Team Practices",
       "topics": ["AI", "Team Dynamics", "Adoption", "Best Practices"],
-      "date": "2025-07-17",
+      "date": "2025-12-10",
       "author": "David Daniel",
       "excerpt": "Why AI tool adoption outcomes vary dramatically between teams, and what the successful ones do differently.",
       "file": "/content/musings/the-uneven-revolution.md"

--- a/public/content/musings/the-uneven-revolution.md
+++ b/public/content/musings/the-uneven-revolution.md
@@ -1,6 +1,6 @@
 # The Uneven Revolution: Why Some Teams Are Thriving with AI Development Tools (And Others Are Just Surviving)
 
-*July 17, 2025*
+*December 10, 2025*
 
 If you have been following the discourse around AI-assisted development, you might think every engineering team is now shipping features at twice the speed while sipping coffee and contemplating philosophy. The reality, as anyone actually doing this work knows, is considerably more nuanced.
 
@@ -112,4 +112,4 @@ That is less exciting than "AI will transform everything" but considerably more 
 
 ---
 
-*This article was created with AI assistance using GPT-4o (July 17, 2025). The author reviewed, edited, and validated all content. Views expressed reflect professional observations and do not represent any specific organization.*
+*This article was created with AI assistance using GPT-4o (July 2025) and Claude Opus (December 10, 2025). The author reviewed, edited, and validated all content. Views expressed reflect professional observations and do not represent any specific organization.*


### PR DESCRIPTION
## Summary
Updates the publication date and AI disclaimer for The Uneven Revolution article to reflect today's date and credit both AI models used.

## Changes
- Update publication date from July 17, 2025 to **December 10, 2025**
- Update manifest date to **2025-12-10**
- Add **Claude Opus (December 10, 2025)** to AI disclaimer alongside GPT-4o (July 2025)

## Files Modified
- `public/content/musings/the-uneven-revolution.md`
- `public/content/musings-manifest.json`

## Test Plan
- [x] Verify article displays December 10, 2025 as publication date
- [x] Check that article appears first in the musings list (most recent)
- [x] Confirm AI disclaimer credits both models with correct dates