### PR TITLE
feat: enhance landing page with research card, professional intro, and SEO enrichments

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,17 @@
           "name": "David Daniel",
           "jobTitle": "Principal Engineer",
           "url": "https://daviddaniel.tech/",
+          "worksFor": {
+            "@type": "Organization",
+            "name": "Nike"
+          },
+          "knowsAbout": [
+            "cloud architecture",
+            "AI-native development",
+            "spec-driven development",
+            "microservices",
+            "agentic engineering"
+          ],
           "sameAs": [
             "https://linkedin.com/in/davidedaniel/",
             "https://github.com/DavideDaniel"
@@ -59,6 +70,6 @@
       </nav>
     </noscript>
     <!-- Crawlable link to research subsite (hidden, replaced by React app on render) -->
-    <a href="/research/" style="position:absolute;left:-9999px;opacity:0" aria-hidden="true" tabindex="-1">Technical Research</a>
+    <a href="/research/" style="position:absolute;left:-9999px;opacity:0" aria-hidden="true" tabindex="-1">Technical Research on Spec-Driven Development Frameworks and AI Development Tools</a>
   </body>
 </html>

--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -19,12 +19,25 @@ function Welcome() {
 
         <section className="welcome-description">
           <p>
-            This site hosts multiple pages with different content and experiments.
-            Explore the sections below to see what's available.
+            Principal Engineer specializing in agentic engineering, AI transformations,
+            cloud architecture, and scalable platform design. This site hosts technical
+            research on spec-driven development frameworks and agentic AI tools, alongside
+            reflections on AI engineering practices.
           </p>
         </section>
 
         <nav className="welcome-nav">
+          <div className="nav-card">
+            <h2>🔬 Technical Research</h2>
+            <p>
+              Spec-driven development frameworks, agentic AI tools, and research into
+              methodologies like BMAD and SpecKit for scalable AI-native engineering.
+            </p>
+            <a href="/research/" className="nav-link">
+              Explore Research →
+            </a>
+          </div>
+
           <div className="nav-card">
             <h2>📝 Bio (Archive)</h2>
             <p>
@@ -35,10 +48,10 @@ function Welcome() {
             </Link>
           </div>
 
-          <div className="nav-card">
-            <h2>💭 Musings on AI Engineering</h2>
+          <div className="nav-card secondary">
+            <h2>💭 Musings</h2>
             <p>
-              Practical insights on AI's impact on software engineering—covering workflows, tools, and best practices.
+              Reflections on AI's impact on software engineering.
             </p>
             <Link to="/musings" className="nav-link">
               Read Musings →
@@ -47,7 +60,11 @@ function Welcome() {
         </nav>
 
         <footer className="welcome-footer">
-          <p>Built with React + Vite | Hosted on GitHub Pages</p>
+          <p>&copy; 2026 David Daniel &middot; Principal Engineer</p>
+          <div className="footer-links">
+            <a href="https://linkedin.com/in/davidedaniel/" rel="me">LinkedIn</a>
+            <a href="https://github.com/DavideDaniel" rel="me">GitHub</a>
+          </div>
         </footer>
       </div>
     </div>

--- a/src/styles/Welcome.css
+++ b/src/styles/Welcome.css
@@ -107,12 +107,38 @@
   opacity: 1;
 }
 
+.nav-card.secondary {
+  opacity: 0.75;
+  font-size: 0.95rem;
+}
+
+.nav-card.secondary h2 {
+  font-size: 1.25rem;
+}
+
 .welcome-footer {
   text-align: center;
   padding-top: 30px;
   border-top: 1px solid #e0e0e0;
   color: var(--light-text);
   font-size: 0.9rem;
+}
+
+.footer-links {
+  margin-top: 8px;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+
+.footer-links a {
+  color: var(--light-text);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: var(--primary-color);
 }
 
 /* Responsive Design */


### PR DESCRIPTION
- Replace generic welcome text with credential-focused professional intro (E-E-A-T)
- Add Research nav card linking to /research/ VitePress subsite with keyword-rich description
- Lower Musings card profile with secondary styling
- Update footer with copyright, author identity, and LinkedIn/GitHub links (rel="me")
- Enrich hidden crawlable anchor with descriptive keyword text
- Add worksFor (Nike) and knowsAbout to JSON-LD Person schema

https://claude.ai/code/session_01PmZ8kgNLEZtM6Y1L5i4NBr