### PR TITLE
Add SSR pre-rendering and SEO infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — Agent Instructions for DavideDaniel.github.io
+
+## Project Overview
+React 18 + Vite portfolio site deployed to GitHub Pages at daviddaniel.tech
+
+## Content Policy (CRITICAL)
+- NEVER modify existing visible content, text, copy, headings, styles, CSS, layouts, or user-facing behavior without explicit user approval
+- SEO infrastructure changes (meta tags in `<head>`, structured data `<script>` tags, config files) are safe to add without approval
+- Treat all existing visible content as frozen unless the user explicitly requests content changes
+
+## SEO Requirements (MANDATORY — do not regress these)
+- Pre-rendering must be maintained — every route must output full static HTML at build time. Verify by checking that dist/index.html contains visible text, not just `<div id="root"></div>`
+- Every page component must have a `<Helmet>` block with unique title, description, canonical URL, and OG tags
+- public/robots.txt must exist and must NOT contain `Disallow: /`
+- public/sitemap.xml must exist and be updated when new routes are added
+- public/CNAME must exist and contain exactly: `daviddaniel.tech`
+- ALL canonical URLs, OG URLs, and sitemap entries must use `https://daviddaniel.tech` — NEVER `davidedaniel.github.io`
+- JSON-LD structured data in index.html must not be removed
+- When adding new pages/routes: add Helmet block, add sitemap entry, ensure pre-rendering covers the new route (add to `scripts/prerender.js` routes array)
+
+## Build & Deploy
+- `npm run build` produces pre-rendered HTML with full content via Vite SSR
+- Build pipeline: `vite build` (client) → `vite build --ssr` (server) → `node scripts/prerender.js` (inject HTML)
+- Deployment is via GitHub Actions to GitHub Pages
+- Verify after build: dist/index.html should contain rendered text, not empty div
+- Verify: dist/robots.txt, dist/sitemap.xml, dist/CNAME all present
+
+## Tech Stack
+- React 18, Vite, React Router, react-helmet-async
+- GitHub Pages with custom domain (daviddaniel.tech)
+- Pre-rendering via Vite SSR build + custom prerender script (scripts/prerender.js)
+
+## Key Files
+- `src/entry-server.jsx` — SSR entry point for pre-rendering
+- `scripts/prerender.js` — Post-build script that renders each route to static HTML
+- `src/main.jsx` — Client entry point with HelmetProvider and hydration support
+- `public/robots.txt`, `public/sitemap.xml`, `public/CNAME` — SEO infrastructure files

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The project uses GitHub Actions for automatic deployment:
 1. Push to `main` branch
 2. GitHub Actions builds the project
 3. Deploys to GitHub Pages
-4. Site is live at `https://davidedaniel.github.io`
+4. Site is live at `https://daviddaniel.tech`
 
 ### Manual Deployment
 
@@ -226,7 +226,7 @@ This project is open source and available under the MIT License.
 **David Enoch Daniel** - Web Developer
 
 - GitHub: [@DavideDaniel](https://github.com/DavideDaniel)
-- Portfolio: [davidedaniel.github.io](https://davidedaniel.github.io)
+- Portfolio: [daviddaniel.tech](https://daviddaniel.tech)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,22 @@
         }
       }
     </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "David Daniel",
+        "jobTitle": "Principal Engineer",
+        "url": "https://daviddaniel.tech/",
+        "sameAs": [
+          "https://github.com/DavideDaniel",
+          "https://linkedin.com/in/davidedaniel/"
+        ]
+      }
+    </script>
+    <!-- Identity verification links -->
+    <link rel="me" href="https://github.com/DavideDaniel" />
+    <link rel="me" href="https://linkedin.com/in/davidedaniel/" />
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "gray-matter": "^4.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^2.0.5",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.28.0",
         "remark-gfm": "^4.0.1"
@@ -3054,6 +3055,15 @@
       "integrity": "sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==",
       "license": "MIT"
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -4624,6 +4634,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-markdown": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -4880,6 +4910,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && vite build --ssr src/entry-server.jsx --outDir dist/server && node scripts/prerender.js",
     "preview": "vite preview",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{js,jsx,css}\"",
@@ -15,6 +15,7 @@
     "gray-matter": "^4.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.28.0",
     "remark-gfm": "^4.0.1"

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+daviddaniel.tech

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Allow: /
-Disallow: /research/musings/
 
-Sitemap: https://daviddaniel.tech/research/sitemap.xml
+Sitemap: https://daviddaniel.tech/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://daviddaniel.tech/</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://daviddaniel.tech/bio</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://daviddaniel.tech/musings</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://daviddaniel.tech/research/</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -1,0 +1,57 @@
+/**
+ * Post-build pre-rendering script
+ *
+ * Renders each route to static HTML using the SSR bundle produced by Vite.
+ * This runs after both the client and server builds complete.
+ *
+ * @ai-context When adding new routes, add them to the `routes` array below.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const dist = path.resolve(__dirname, '../dist')
+
+// All routes to pre-render — keep in sync with src/App.jsx
+const routes = ['/', '/bio', '/musings']
+
+async function prerender() {
+  const template = fs.readFileSync(path.resolve(dist, 'index.html'), 'utf-8')
+  const { render } = await import(path.resolve(dist, 'server/entry-server.js'))
+
+  for (const route of routes) {
+    const { html } = render(route)
+
+    // Inject pre-rendered content into the root div
+    const output = template.replace(
+      '<div id="root"></div>',
+      `<div id="root">${html}</div>`
+    )
+
+    // Determine output path
+    const outputPath =
+      route === '/'
+        ? path.resolve(dist, 'index.html')
+        : path.resolve(dist, route.slice(1), 'index.html')
+
+    // Ensure directory exists and write
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+    fs.writeFileSync(outputPath, output)
+    console.log(`Pre-rendered: ${route} -> ${path.relative(dist, outputPath)}`)
+  }
+
+  // Create 404.html as a copy of index.html for GitHub Pages SPA fallback
+  const indexHtml = fs.readFileSync(path.resolve(dist, 'index.html'), 'utf-8')
+  fs.writeFileSync(path.resolve(dist, '404.html'), indexHtml)
+  console.log('Created 404.html for SPA fallback')
+
+  // Clean up server bundle (not needed in deployment)
+  fs.rmSync(path.resolve(dist, 'server'), { recursive: true, force: true })
+  console.log('Cleaned up server bundle')
+}
+
+prerender().catch((err) => {
+  console.error('Pre-rendering failed:', err)
+  process.exit(1)
+})

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -1,0 +1,27 @@
+/**
+ * Server-side entry point for pre-rendering
+ *
+ * @ai-context This file is used during the build to pre-render each route
+ * to static HTML. It is NOT used at runtime in the browser.
+ */
+import { renderToString } from 'react-dom/server'
+import { StaticRouter } from 'react-router-dom/server'
+import { HelmetProvider } from 'react-helmet-async'
+import App from './App'
+
+/**
+ * Render a given URL path to an HTML string
+ * @param {string} url - The route path to render (e.g. '/', '/bio')
+ * @returns {{ html: string, helmet: object }} The rendered HTML and helmet context
+ */
+export function render(url) {
+  const helmetContext = {}
+  const html = renderToString(
+    <HelmetProvider context={helmetContext}>
+      <StaticRouter location={url}>
+        <App />
+      </StaticRouter>
+    </HelmetProvider>
+  )
+  return { html, helmet: helmetContext.helmet }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,17 +3,31 @@
  *
  * @ai-context This initializes the React app with routing enabled.
  * The BrowserRouter provides client-side navigation capabilities.
+ * HelmetProvider enables per-page <head> management for SEO.
+ * Uses hydrateRoot when pre-rendered HTML is present, createRoot otherwise.
  */
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
 import App from './App'
 import './styles/index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+const rootElement = document.getElementById('root')
+
+const app = (
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>,
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
+  </React.StrictMode>
 )
+
+// Use hydrateRoot if the page was pre-rendered, createRoot otherwise
+if (rootElement.hasChildNodes()) {
+  ReactDOM.hydrateRoot(rootElement, app)
+} else {
+  ReactDOM.createRoot(rootElement).render(app)
+}

--- a/src/pages/Bio.jsx
+++ b/src/pages/Bio.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 import ProjectCard from '../components/ProjectCard'
 import Testimonial from '../components/Testimonial'
 import ResumeModal from '../components/ResumeModal'
@@ -123,6 +124,20 @@ function Bio() {
 
   return (
     <div className="bio-container">
+      <Helmet>
+        <title>Bio — David Daniel | Web Developer Portfolio</title>
+        <meta name="description" content="David Daniel's portfolio — web developer with experience in React, Node.js, and full-stack development. View projects, skills, and testimonials." />
+        <link rel="canonical" href="https://daviddaniel.tech/bio" />
+        <meta name="robots" content="index, follow" />
+        <meta property="og:title" content="Bio — David Daniel | Web Developer Portfolio" />
+        <meta property="og:description" content="David Daniel's portfolio — web developer with experience in React, Node.js, and full-stack development. View projects, skills, and testimonials." />
+        <meta property="og:url" content="https://daviddaniel.tech/bio" />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="David Daniel" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Bio — David Daniel | Web Developer Portfolio" />
+        <meta name="twitter:description" content="David Daniel's portfolio — web developer with experience in React, Node.js, and full-stack development. View projects, skills, and testimonials." />
+      </Helmet>
       {/* Navigation */}
       <nav className="bio-nav">
         <div className="nav-container">
@@ -257,17 +272,17 @@ function Bio() {
                   <i className="icon-email">✉</i>
                 </span>
               </a>
-              <a href="https://www.linkedin.com/in/davidedaniel" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+              <a href="https://www.linkedin.com/in/davidedaniel" target="_blank" rel="me noopener noreferrer" aria-label="LinkedIn">
                 <span className="social-icon">
                   <i className="icon-linkedin">in</i>
                 </span>
               </a>
-              <a href="https://github.com/davidedaniel" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <a href="https://github.com/davidedaniel" target="_blank" rel="me noopener noreferrer" aria-label="GitHub">
                 <span className="social-icon">
                   <i className="icon-github">⚙</i>
                 </span>
               </a>
-              <a href="https://www.twitter.com/davidedaniel" target="_blank" rel="noopener noreferrer" aria-label="Twitter">
+              <a href="https://www.twitter.com/davidedaniel" target="_blank" rel="me noopener noreferrer" aria-label="Twitter">
                 <span className="social-icon">
                   <i className="icon-twitter">🐦</i>
                 </span>

--- a/src/pages/Musings.jsx
+++ b/src/pages/Musings.jsx
@@ -13,6 +13,7 @@
 
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import '../styles/Musings.css';
@@ -136,10 +137,28 @@ const Musings = () => {
     setMarkdownContent('');
   };
 
+  const musingsHelmet = (
+    <Helmet>
+      <title>Musings on AI Engineering | David Daniel</title>
+      <meta name="description" content="Practical insights on AI's impact on software engineering — covering workflows, tools, and best practices for modern development." />
+      <link rel="canonical" href="https://daviddaniel.tech/musings" />
+      <meta name="robots" content="index, follow" />
+      <meta property="og:title" content="Musings on AI Engineering | David Daniel" />
+      <meta property="og:description" content="Practical insights on AI's impact on software engineering — covering workflows, tools, and best practices for modern development." />
+      <meta property="og:url" content="https://daviddaniel.tech/musings" />
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="David Daniel" />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content="Musings on AI Engineering | David Daniel" />
+      <meta name="twitter:description" content="Practical insights on AI's impact on software engineering — covering workflows, tools, and best practices for modern development." />
+    </Helmet>
+  );
+
   // Render loading state
   if (isLoading) {
     return (
       <div className="musings-page">
+        {musingsHelmet}
         <div className="musings-container">
           <div className="loading">Loading musings...</div>
         </div>
@@ -151,6 +170,7 @@ const Musings = () => {
   if (error) {
     return (
       <div className="musings-page">
+        {musingsHelmet}
         <div className="musings-container">
           <div className="error">
             <h2>Error Loading Content</h2>
@@ -166,6 +186,7 @@ const Musings = () => {
   if (selectedMusing) {
     return (
       <div className="musings-page">
+        {musingsHelmet}
         <div className="musings-container">
           <div className="article-view">
             <div className="article-header">
@@ -199,6 +220,7 @@ const Musings = () => {
   // Render list view (default)
   return (
     <div className="musings-page">
+      {musingsHelmet}
       <div className="musings-container">
         {/* Header */}
         <header className="musings-header">

--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 import '../styles/Welcome.css'
 
 /**
@@ -12,6 +13,20 @@ import '../styles/Welcome.css'
 function Welcome() {
   return (
     <div className="welcome-container">
+      <Helmet>
+        <title>David Daniel | Principal Engineer</title>
+        <meta name="description" content="David Daniel — Principal Engineer specializing in agentic engineering, AI transformations, cloud architecture, and scalable platform design." />
+        <link rel="canonical" href="https://daviddaniel.tech/" />
+        <meta name="robots" content="index, follow" />
+        <meta property="og:title" content="David Daniel | Principal Engineer" />
+        <meta property="og:description" content="David Daniel — Principal Engineer specializing in agentic engineering, AI transformations, cloud architecture, and scalable platform design." />
+        <meta property="og:url" content="https://daviddaniel.tech/" />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="David Daniel" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="David Daniel | Principal Engineer" />
+        <meta name="twitter:description" content="David Daniel — Principal Engineer specializing in agentic engineering, AI transformations, cloud architecture, and scalable platform design." />
+      </Helmet>
       <div className="welcome-content">
         <header className="welcome-header">
           <h1 className="subtitle">David Daniel | Principal Engineer</h1>

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,4 +10,8 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
   },
+  // SSR config for pre-rendering — ensures CSS imports are handled correctly
+  ssr: {
+    noExternal: ['react-helmet-async'],
+  },
 })


### PR DESCRIPTION
## Summary
Implements server-side rendering (SSR) pre-rendering for static HTML generation and comprehensive SEO infrastructure to improve search engine visibility and site discoverability.

## Key Changes

**Pre-rendering & SSR**
- Added `scripts/prerender.js` — post-build script that renders each route to static HTML using Vite's SSR bundle
- Created `src/entry-server.jsx` — server-side entry point for pre-rendering with React DOM's `renderToString`
- Updated `src/main.jsx` to use `hydrateRoot` when pre-rendered HTML is present, falling back to `createRoot` for client-only rendering
- Modified `vite.config.js` to configure SSR build with `react-helmet-async` as non-external dependency
- Updated `package.json` build script to run: client build → SSR build → pre-render script

**SEO Infrastructure**
- Added `public/sitemap.xml` with all routes (/, /bio, /musings, /research/) with proper priority and change frequency
- Added `public/CNAME` for GitHub Pages custom domain configuration
- Updated `public/robots.txt` to allow all routes and reference the sitemap
- Added JSON-LD structured data (`Person` schema) to `index.html`
- Added identity verification links (`rel="me"`) to GitHub and LinkedIn in `index.html`

**Per-Page SEO**
- Added `<Helmet>` blocks to all page components (`Welcome.jsx`, `Bio.jsx`, `Musings.jsx`) with:
  - Unique titles and descriptions for each route
  - Canonical URLs using `https://daviddaniel.tech`
  - Open Graph (og:*) meta tags for social sharing
  - Twitter Card meta tags
  - Robots meta tags for indexing
- Added `react-helmet-async` dependency for server-safe head management
- Updated social links in `Bio.jsx` to include `rel="me"` for identity verification

**Documentation**
- Added `CLAUDE.md` with comprehensive agent instructions covering content policy, SEO requirements, build pipeline, and key files

## Implementation Details
- Pre-rendering happens post-build: the script reads the Vite-generated `index.html` template and SSR bundle, renders each route, and injects the HTML into the root div
- A `404.html` is created as a copy of `index.html` to enable GitHub Pages SPA fallback routing
- The server bundle is cleaned up after pre-rendering since it's not needed in deployment
- All canonical URLs and sitemap entries use the custom domain `daviddaniel.tech` (not `davidedaniel.github.io`)
- README.md updated to reflect the custom domain deployment URL

https://claude.ai/code/session_01Vx8oFmBrLi7M9yPL8dq62L