### PR TITLE
Add server-side helmet integration for SEO meta tags

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://daviddaniel.tech/sitemap.xml
+Sitemap: https://daviddaniel.tech/research/sitemap.xml

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -21,13 +21,72 @@ async function prerender() {
   const { render } = await import(path.resolve(dist, 'server/entry-server.js'))
 
   for (const route of routes) {
-    const { html } = render(route)
+    const { html, helmet } = render(route)
 
-    // Inject pre-rendered content into the root div
-    const output = template.replace(
+    // Start with injecting pre-rendered content into the root div
+    let output = template.replace(
       '<div id="root"></div>',
       `<div id="root">${html}</div>`
     )
+
+    // Inject page-specific <head> tags from react-helmet-async
+    if (helmet) {
+      const helmetTitle = helmet.title.toString()
+      const helmetMeta = helmet.meta.toString()
+      const helmetLink = helmet.link.toString()
+      const helmetScript = helmet.script.toString()
+
+      // Replace the existing <title> with the page-specific one
+      if (helmetTitle) {
+        output = output.replace(/<title>[^<]*<\/title>/, helmetTitle)
+      }
+
+      // Replace homepage meta description and robot-indexable meta tags with page-specific ones
+      // Remove existing meta tags that helmet will provide (description, robots, og:*, twitter:*)
+      if (helmetMeta) {
+        output = output.replace(
+          /\s*<meta name="description"[^>]*>/g,
+          ''
+        )
+        output = output.replace(
+          /\s*<meta name="robots"[^>]*>/g,
+          ''
+        )
+        output = output.replace(
+          /\s*<meta property="og:[^"]*"[^>]*>/g,
+          ''
+        )
+        output = output.replace(
+          /\s*<!-- Open Graph -->/g,
+          ''
+        )
+        output = output.replace(
+          /\s*<meta name="twitter:[^"]*"[^>]*>/g,
+          ''
+        )
+        output = output.replace(
+          /\s*<!-- Twitter Card -->/g,
+          ''
+        )
+        // Inject helmet meta tags before </head>
+        output = output.replace('</head>', `    ${helmetMeta}\n  </head>`)
+      }
+
+      // Replace homepage canonical link with page-specific one
+      if (helmetLink) {
+        output = output.replace(
+          /\s*<link rel="canonical"[^>]*>/g,
+          ''
+        )
+        // Inject helmet link tags before </head>
+        output = output.replace('</head>', `    ${helmetLink}\n  </head>`)
+      }
+
+      // Inject any page-specific script tags (e.g., JSON-LD structured data)
+      if (helmetScript) {
+        output = output.replace('</head>', `    ${helmetScript}\n  </head>`)
+      }
+    }
 
     // Determine output path
     const outputPath =


### PR DESCRIPTION
## Summary
This PR integrates react-helmet-async with the server-side prerendering pipeline to enable per-page SEO optimization. Page-specific meta tags, titles, and structured data are now properly injected into the prerendered HTML output.

## Key Changes
- **Enhanced prerender.js**: Modified the prerendering logic to extract and inject helmet-generated head tags (title, meta, link, script) into the final HTML output
  - Extracts helmet data from the server render function
  - Removes conflicting homepage meta tags (description, robots, Open Graph, Twitter Card, canonical links)
  - Injects page-specific SEO tags before the closing `</head>` tag
  - Supports dynamic title, meta descriptions, social media tags, canonical links, and structured data (JSON-LD)

- **Updated robots.txt**: Added a second sitemap reference for the research section (`https://daviddaniel.tech/research/sitemap.xml`)

## Implementation Details
The prerender script now:
1. Receives both `html` and `helmet` objects from the server render function
2. Performs targeted regex replacements to remove generic homepage meta tags that would be overridden
3. Sequentially injects helmet-provided tags before `</head>` to ensure page-specific SEO metadata takes precedence
4. Maintains proper HTML formatting with consistent indentation

This enables dynamic SEO optimization for each prerendered route while maintaining a single base template.

https://claude.ai/code/session_01BhrRL6vTPLxrRpznU2x572