### PR TITLE
Add Google Site Verification meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google-site-verification" content="TiYj2JQabBCnL_tTF0AwmzsXC8mhwTWz_W0rvsTYHok" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="David Daniel - Principal Engineer. Portfolio, technical research, and musings on AI engineering, software architecture, and modern development practices." />


### PR DESCRIPTION
## Summary
Added Google Site Verification meta tag to the HTML head to enable Google Search Console verification for the site.

## Changes
- Added `<meta name="google-site-verification" content="TiYj2JQabBCnL_tTF0AwmzsXC8mhwTWz_W0rvsTYHok" />` to the document head in `index.html`

## Details
This meta tag is required by Google Search Console to verify ownership of the domain. It allows the site to be properly indexed and monitored through Google's search tools.

https://claude.ai/code/session_01SsniHtfDYSC4X4pKvTN57D