### PR TITLE
seo: de-index Musings page from search engines

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <h1>David Daniel | Principal Engineer</h1>
         <ul>
           <li><a href="/bio">Bio</a></li>
-          <li><a href="/musings">Musings on AI Engineering</a></li>
+          <li><a href="/musings" rel="nofollow">Musings on AI Engineering</a></li>
           <li><a href="/research/">Technical Research</a></li>
         </ul>
       </nav>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,12 +13,6 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://daviddaniel.tech/musings</loc>
-    <lastmod>2026-02-28</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://daviddaniel.tech/research/</loc>
     <lastmod>2026-02-28</lastmod>
     <changefreq>weekly</changefreq>

--- a/src/pages/Musings.jsx
+++ b/src/pages/Musings.jsx
@@ -142,7 +142,7 @@ const Musings = () => {
       <title>Musings on AI Engineering | David Daniel</title>
       <meta name="description" content="Practical insights on AI's impact on software engineering — covering workflows, tools, and best practices for modern development." />
       <link rel="canonical" href="https://daviddaniel.tech/musings" />
-      <meta name="robots" content="index, follow" />
+      <meta name="robots" content="noindex, follow" />
       <meta property="og:title" content="Musings on AI Engineering | David Daniel" />
       <meta property="og:description" content="Practical insights on AI's impact on software engineering — covering workflows, tools, and best practices for modern development." />
       <meta property="og:url" content="https://daviddaniel.tech/musings" />

--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -68,7 +68,7 @@ function Welcome() {
             <p>
               Reflections on AI's impact on software engineering.
             </p>
-            <Link to="/musings" className="nav-link">
+            <Link to="/musings" className="nav-link" rel="nofollow">
               Read Musings →
             </Link>
           </div>


### PR DESCRIPTION
Keep the Musings page fully accessible to visitors while preventing search engine indexing. Changes:
- Set robots meta to noindex, follow in Musings.jsx Helmet block
- Remove musings entry from sitemap.xml
- Add rel="nofollow" to Musings links in index.html noscript nav and Welcome.jsx

https://claude.ai/code/session_017WcBoZgBD3rXWHyuGbpDaE