### PR TITLE
fix: legacy research-path redirects + deep research links (research#28)

### DIFF
--- a/public/papers/autonomous-agents/benchmarks/index.html
+++ b/public/papers/autonomous-agents/benchmarks/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Moved: SWE-bench &amp; Multi-Agent Execution | David Daniel Research</title>
+<link rel="canonical" href="https://daviddaniel.tech/research/papers/autonomous-agents/benchmarks">
+<meta http-equiv="refresh" content="0; url=/research/papers/autonomous-agents/benchmarks">
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This page moved to <a href="/research/papers/autonomous-agents/benchmarks">/research/papers/autonomous-agents/benchmarks</a>.</p>
+</body>
+</html>

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -100,10 +100,15 @@ async function prerender() {
     console.log(`Pre-rendered: ${route} -> ${path.relative(dist, outputPath)}`)
   }
 
-  // Create 404.html as a copy of index.html for GitHub Pages SPA fallback
+  // Create 404.html as a copy of index.html for GitHub Pages SPA fallback.
+  // Legacy research paths (/papers/*, /articles/*) predate the /research/ base
+  // and still get crawled occasionally (see research repo issue #28); redirect
+  // them client-side before the SPA hydrates.
   const indexHtml = fs.readFileSync(path.resolve(dist, 'index.html'), 'utf-8')
-  fs.writeFileSync(path.resolve(dist, '404.html'), indexHtml)
-  console.log('Created 404.html for SPA fallback')
+  const legacyRedirect =
+    '<script>(function(){var p=location.pathname;if(/^\\/(papers|articles)\\//.test(p)){location.replace("/research"+p+location.search+location.hash)}})()</script>'
+  fs.writeFileSync(path.resolve(dist, '404.html'), indexHtml.replace('<head>', '<head>' + legacyRedirect))
+  console.log('Created 404.html for SPA fallback (with legacy /papers,/articles redirect)')
 
   // Clean up server bundle (not needed in deployment)
   fs.rmSync(path.resolve(dist, 'server'), { recursive: true, force: true })

--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -58,6 +58,14 @@ function Welcome() {
               Spec-driven development frameworks, agentic AI tools, and research into
               methodologies like BMAD and SpecKit for scalable AI-native engineering.
             </p>
+            <ul className="research-list">
+              <li><a href="/research/papers/harness-engineering/">Harness Engineering</a></li>
+              <li><a href="/research/papers/agentic-pricing-break/">When the Loop Never Stops</a></li>
+              <li><a href="/research/papers/autonomous-agents/">Autonomous AI Agents</a></li>
+              <li><a href="/research/papers/sdd-frameworks/">Spec-Driven Development Frameworks</a></li>
+              <li><a href="/research/papers/agentic-tools/">Agentic Development Tools</a></li>
+              <li><a href="/research/articles/specification-layer/">The Specification Layer</a></li>
+            </ul>
             <a href="/research/" className="nav-link">
               Explore Research →
             </a>

--- a/src/styles/Welcome.css
+++ b/src/styles/Welcome.css
@@ -159,3 +159,15 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Deep links inside the research nav-card (research repo issue #28: internal
+   links to specific papers help crawled-not-indexed pages) */
+.research-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+}
+.research-list li {
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
See commit message. Build verified: prerendered HTML intact, redirect script valid (tested both legacy and normal paths), stub present in dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)