### PR TITLE
fix(seo): scope homepage JSON-LD to the homepage only

### DIFF
--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -29,6 +29,19 @@ async function prerender() {
       `<div id="root">${html}</div>`
     )
 
+    // The homepage's JSON-LD (WebSite/Person) is hardcoded in index.html's <head>
+    // (kept there per the SEO invariant in CLAUDE.md). For non-home routes, strip
+    // it so the homepage entity markup does not leak onto subpages — each page
+    // supplies its own structured data via Helmet (e.g. About's ProfilePage).
+    // This runs before helmet script injection below, so only template-level
+    // ld+json blocks are removed, never the page-specific ones.
+    if (route !== '/') {
+      output = output.replace(
+        /\s*<script type="application\/ld\+json">[\s\S]*?<\/script>/g,
+        ''
+      )
+    }
+
     // Inject page-specific <head> tags from react-helmet-async
     if (helmet) {
       const helmetTitle = helmet.title.toString()


### PR DESCRIPTION
## Problem

The homepage's `WebSite` + `Person` structured data is hardcoded in `index.html`'s `<head>`. The prerender step strips/replaces template meta, canonical, and title tags per route, but **not** the `application/ld+json` blocks, so the homepage entity markup was copied verbatim onto every prerendered page.

Result, verified in the built output before this change:

- `/about/` shipped the homepage `WebSite` + a duplicate `Person` (pointing at `daviddaniel.tech/`) **on top of** its intended `ProfilePage` → `Person` (pointing at `/about/`). Three `Person` nodes, conflicting URLs — exactly the kind of noise that dilutes the authorship/E-E-A-T signal the About page was added to send.
- `/bio/` carried homepage `WebSite`/`Person` entity markup on an archive page.

## Fix

Strip template-level `application/ld+json` blocks from **non-home** routes during prerender, before per-page Helmet scripts are injected (so only template-level blocks are removed, never the page-specific ones).

`index.html` is left untouched, so the CLAUDE.md invariant ("JSON-LD structured data in index.html must not be removed") still holds and the homepage keeps its full markup.

## Verification (built `dist/`)

| Page | JSON-LD @types after fix |
|------|--------------------------|
| `/` | `WebSite`, `Person`, `Organization`, `Person` (unchanged) |
| `/about/` | `ProfilePage`, `Person`, `Organization`×2, `EducationalOrganization`, `PostalAddress` (only its own) |
| `/bio/` | none |

Titles and canonicals remain correct per page. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)